### PR TITLE
fix queue rooms

### DIFF
--- a/testing/client/src/api/RoomsAPI.js
+++ b/testing/client/src/api/RoomsAPI.js
@@ -21,25 +21,11 @@ function RoomsAPI(token) {
     },[callback, building, sort, search, page])
 
     const incrementPop= async (room) => {
-        const newroom = {
-            ...room,
-            popularity:room.popularity+1,
-            images:room.roomPicUrl
-        }
         await axios.patch(`/api/rooms/incrementpop/${room._id}`, {}, {
             headers: {Authorization: token}
         })
     }
     const decrementPop= async (room) => {
-        var newpop = 0
-        if (room.popularity > 0) {
-            newpop = room.popularity-1
-        }
-        const newroom = {
-            ...room,
-            popularity:newpop,
-            images:room.roomPicUrl
-        }
         await axios.patch(`/api/rooms/decrementpop/${room._id}`, {}, {
             headers: {Authorization: token}
         })

--- a/testing/client/src/api/StudentAPI.js
+++ b/testing/client/src/api/StudentAPI.js
@@ -18,12 +18,17 @@ function StudentAPI(token) {
                     setIsLogged(true)
                     res.data.role === 1 ? setIsAdmin(true) : setIsAdmin(false)
 
-                    setQueue(res.data.queue)
 
                 } catch (err) {
                     alert(err.response.data.msg)
                 }
             }
+            axios.get('/student/queue', {
+                headers: {Authorization: token}
+            }).then((res)=>{
+                console.log(res) 
+                setQueue(res.data)
+            })
 
             getStudent()
 
@@ -42,7 +47,7 @@ function StudentAPI(token) {
         if(!currentRoomIds.includes(room._id)){
             setQueue([...queue, {...room, quantity: 1}])
 
-            await axios.patch('/student/addqueue', {queue: [...queue, {...room, quantity: 1}]}, {
+            await axios.patch('/student/addqueue', {queue: [...queue, room._id]}, {
                 headers: {Authorization: token}
             })
 

--- a/testing/client/src/api/StudentAPI.js
+++ b/testing/client/src/api/StudentAPI.js
@@ -26,7 +26,6 @@ function StudentAPI(token) {
             axios.get('/student/queue', {
                 headers: {Authorization: token}
             }).then((res)=>{
-                console.log(res) 
                 setQueue(res.data)
             })
 

--- a/testing/client/src/components/mainpages/queue/Queue.js
+++ b/testing/client/src/components/mainpages/queue/Queue.js
@@ -5,8 +5,10 @@ import axios from 'axios'
 function Queue() {
     const state = useContext(GlobalState)
     const [queue, setQueue] = state.studentAPI.queue
+    const getRoom = state.roomsAPI.getRoom
     const [token] = state.token
     const [total, setTotal] = useState(0)
+    // const [rooms, setRooms] = useState([])
     const decrementPop = state.roomsAPI.decrementPop
 
     useEffect(() =>{
@@ -17,9 +19,7 @@ function Queue() {
 
             setTotal(total)
         }
-
         getTotal()
-
     },[queue])
 
     const addToQueue = async (queue) =>{
@@ -48,7 +48,9 @@ function Queue() {
     return (
         <div>
             {
-                queue.map(room => (
+                queue.map(room => {
+                    console.log("room:", room) 
+                    return(
                     <div className="detail queue" key={room._id}>
                         <img className="image" src={room.roomPicUrl}  alt="" />
 
@@ -70,7 +72,7 @@ function Queue() {
                             </div>
                         </div>
                     </div>
-                ))
+                )})
             }
         </div>
     )

--- a/testing/client/src/components/mainpages/queue/Queue.js
+++ b/testing/client/src/components/mainpages/queue/Queue.js
@@ -5,10 +5,8 @@ import axios from 'axios'
 function Queue() {
     const state = useContext(GlobalState)
     const [queue, setQueue] = state.studentAPI.queue
-    const getRoom = state.roomsAPI.getRoom
     const [token] = state.token
     const [total, setTotal] = useState(0)
-    // const [rooms, setRooms] = useState([])
     const decrementPop = state.roomsAPI.decrementPop
 
     useEffect(() =>{
@@ -48,9 +46,7 @@ function Queue() {
     return (
         <div>
             {
-                queue.map(room => {
-                    console.log("room:", room) 
-                    return(
+                queue.map(room => (
                     <div className="detail queue" key={room._id}>
                         <img className="image" src={room.roomPicUrl}  alt="" />
 
@@ -72,7 +68,7 @@ function Queue() {
                             </div>
                         </div>
                     </div>
-                )})
+                ))
             }
         </div>
     )

--- a/testing/controllers/studentCtrl.js
+++ b/testing/controllers/studentCtrl.js
@@ -1,4 +1,5 @@
 const Students = require('../models/studentModel')
+const Rooms = require('../models/roomModel')
 const bcrypt = require('bcrypt')
 const jwt = require('jsonwebtoken')
 
@@ -97,6 +98,20 @@ const studentCtrl = {
             if(!student) return res.status(400).json({msg: "Student does not exist."})
 
             res.json(student)
+        } catch (err) {
+            return res.status(500).json({msg: err.message})
+        }
+    },
+    getQueue: async (req, res) =>{
+        try {
+            const student = await Students.findById(req.student.id).select('-password')
+            if(!student) return res.status(400).json({msg: "Student does not exist."})
+
+            const queue = await Rooms.find({
+                '_id': { $in: student.queue}
+            })
+
+            res.json(queue)
         } catch (err) {
             return res.status(500).json({msg: err.message})
         }

--- a/testing/routes/studentRouter.js
+++ b/testing/routes/studentRouter.js
@@ -14,6 +14,8 @@ router.get('/infor', auth,  studentCtrl.getStudent)
 
 router.patch('/addqueue', auth, studentCtrl.addQueue)
 
+router.get('/queue', auth, studentCtrl.getQueue)
+
 router.get('/history', auth, studentCtrl.history)
 
 


### PR DESCRIPTION
bug: room entries on queue page were not updating on change (noticeable now with popularity)
fix: changed 'queue' field in student collection of database from copies of room objects to room object ids
method: made a route (edits to studentrouter and studentctrl) to get a student's queue and function call (edits to studentAPI and Queue) 